### PR TITLE
Fix issue causing database growth due to unremoved old klines

### DIFF
--- a/Trading-Simulator/backend/src/main/java/com/example/backend/currency/ScheduledTasks.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/currency/ScheduledTasks.java
@@ -1,7 +1,5 @@
 package com.example.backend.currency;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
- Added the 'RemoveOldKlines' method to clean up old entries:
  - Keeps only the most recent 1000 klines per currency and interval
  - Delete older klines from database.