### PR TITLE
Add Commodity Channel index with unit and integration tests

### DIFF
--- a/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/AnalyticsController.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/AnalyticsController.java
@@ -185,4 +185,25 @@ public class AnalyticsController {
             return ResponseEntity.status(500).build();
         }
     }
+
+    @GetMapping("/cci/{symbol}/{interval}")
+    public ResponseEntity<BigDecimal> getCci(
+            @PathVariable String symbol,
+            @PathVariable String interval) {
+        try {
+            BigDecimal cached = indicatorCacheService.getCci(symbol.toUpperCase(), interval);
+            if (cached != null) {
+                return ResponseEntity.ok(cached);
+            }
+
+            BigDecimal cci = analyticsService.calculateIndicator(symbol, interval, new CciCalculator());
+
+            indicatorCacheService.saveCci(symbol, interval, cci);
+
+            return ResponseEntity.ok(cci);
+        } catch (Exception e) {
+            logger.error("Error retrieving Cci for {}: {}", symbol, e.getMessage());
+            return ResponseEntity.status(500).build();
+        }
+    }
 }

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/CciCalculator.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/CciCalculator.java
@@ -1,0 +1,74 @@
+package com.example.backend.analytics;
+
+import com.example.backend.currency.HistoricalKline;
+import com.example.backend.exceptions.NotEnoughDataForCalculationException;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Component
+public class CciCalculator implements IndicatorCalculator<BigDecimal> {
+
+    /*
+    The formula for the Commodity Channel Index (CCI)
+    CCI is calculated using the following formula:
+    CCI = (Typical Price - Simple Moving Average) / (0.015 × Mean Deviation)
+    Where:
+    Typical Price (TP) = (High + Low + Close) / 3
+    Simple Moving Average (SMA) is calculated over a specified period (typically 20 periods).
+    Mean Deviation is the average of the absolute differences between the Typical Price and the SMA over the same period.
+     */
+
+    private static final BigDecimal CONSTANT = new BigDecimal("0.015");
+    private static final int PERIODS = 20;
+
+    @Override
+    public BigDecimal calculate(List<HistoricalKline> klines) {
+
+        if (klines.size() < PERIODS) {
+            throw new NotEnoughDataForCalculationException("Not enough data for CCI calculator");
+        }
+
+        List<HistoricalKline> subset = klines.subList(klines.size() - PERIODS, klines.size());
+        // TP
+        BigDecimal sumOfTp = BigDecimal.ZERO;
+        for (HistoricalKline kline : subset) {
+            BigDecimal tp = kline.getHighPrice()
+                    .add(kline.getLowPrice())
+                    .add(kline.getClosePrice())
+                    .divide(BigDecimal.valueOf(3), RoundingMode.HALF_UP);
+            sumOfTp = sumOfTp.add(tp);
+        }
+
+        BigDecimal sma = sumOfTp.divide(BigDecimal.valueOf(PERIODS), RoundingMode.HALF_UP);
+
+        // Mean deviation
+        BigDecimal meanDeviationSum = BigDecimal.ZERO;
+        for (HistoricalKline kline : subset) {
+            BigDecimal tp = kline.getHighPrice()
+                    .add(kline.getLowPrice())
+                    .add(kline.getClosePrice())
+                    .divide(BigDecimal.valueOf(3), RoundingMode.HALF_UP);
+            meanDeviationSum = meanDeviationSum.add(tp.subtract(sma).abs());
+        }
+        BigDecimal meanDeviation = meanDeviationSum.divide(BigDecimal.valueOf(PERIODS), RoundingMode.HALF_UP);
+
+        // CCI
+        HistoricalKline lastKline = klines.get(klines.size() - 1);
+        BigDecimal lastTp = lastKline.getHighPrice()
+                .add(lastKline.getLowPrice())
+                .add(lastKline.getClosePrice())
+                .divide(BigDecimal.valueOf(3), RoundingMode.HALF_UP);
+
+        if (meanDeviation.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+
+        return lastTp
+                .subtract(sma)
+                .divide(CONSTANT.multiply(meanDeviation), RoundingMode.HALF_UP);
+
+    }
+}

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/IndicatorCacheService.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/analytics/IndicatorCacheService.java
@@ -156,4 +156,20 @@ public class IndicatorCacheService {
             return null;
         }
     }
+
+    public void saveCci(String symbol, String interval, BigDecimal value) {
+    String key = "Cci:" + symbol + ":" + interval;
+    redisTemplate.opsForValue().set(key, value.toPlainString(), Duration.ofMinutes(1));
+    }
+
+    public BigDecimal getCci(String symbol, String interval) {
+        String key = "Cci:" + symbol + ":" + interval;
+        try {
+            String val = redisTemplate.opsForValue().get(key);
+            return val != null ? new BigDecimal(val) : null;
+        } catch (Exception e) {
+            logger.error("Redis error loading Cci: {}", e.getMessage());
+            return null;
+        }
+    }
 }

--- a/Trading-Simulator/backend/src/test/java/com/example/backend/analytics/CciCalculatorTest.java
+++ b/Trading-Simulator/backend/src/test/java/com/example/backend/analytics/CciCalculatorTest.java
@@ -1,0 +1,90 @@
+package com.example.backend.analytics;
+
+import com.example.backend.currency.HistoricalKline;
+import com.example.backend.exceptions.NotEnoughDataForCalculationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class CciCalculatorTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cciTestCases")
+    void testCciCalculator(String testName,
+                           List<HistoricalKline> klines,
+                           BigDecimal expectedValue,
+                           boolean expectException) {
+        CciCalculator calculator = new CciCalculator();
+
+        if (expectException) {
+            Assertions.assertThrows(
+                    NotEnoughDataForCalculationException.class,
+                    () -> calculator.calculate(klines),
+                    "Expected NotEnoughDataForCalculationEception for: " + testName
+            );
+        } else {
+            BigDecimal result = calculator.calculate(klines);
+            Assertions.assertEquals(
+                    0,
+                    result.compareTo(expectedValue),
+                    "Cci result mismatch for test: " + testName
+            );
+        }
+    }
+
+    static Stream<Arguments> cciTestCases() {
+        return Stream.of(
+        Arguments.of(
+                "Not enough data (<20 klines) -> exception",
+                createKlines(19, 100, 51, 32),
+                null,
+                true
+        ),
+        Arguments.of(
+                "All prices the same -> meanDeviation = 0 so Cci = 0",
+                createKlinesWithSamePrices(),
+                BigDecimal.ZERO,
+                false
+        ),
+        Arguments.of("Standard case: High = 120, low = 100, Close = 110",
+                createKlines(21, 120, 100, 110),
+                new BigDecimal("126.7"),
+                false
+        )
+        );
+    }
+
+    static List<HistoricalKline> createKlinesWithSamePrices() {
+        List<HistoricalKline> klines = new ArrayList<>();
+        for (int i = 0; i < 21; i++) {
+            klines.add(
+                    HistoricalKline.builder()
+                            .highPrice(BigDecimal.valueOf((double) 15))
+                            .lowPrice(BigDecimal.valueOf((double) 15))
+                            .closePrice(BigDecimal.valueOf((double) 15))
+                            .build()
+            );
+        }
+        return klines;
+    }
+
+    static List<HistoricalKline> createKlines(int count, double high, double low, double close) {
+        List<HistoricalKline> klines = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            klines.add(
+                    HistoricalKline.builder()
+                            .highPrice(BigDecimal.valueOf(high + i))
+                            .lowPrice(BigDecimal.valueOf(low + i))
+                            .closePrice(BigDecimal.valueOf(close + i))
+                            .build()
+            );
+        }
+        return klines;
+    }
+}

--- a/Trading-Simulator/backend/src/test/java/com/example/backend/analytics/CciIntegrationTest.java
+++ b/Trading-Simulator/backend/src/test/java/com/example/backend/analytics/CciIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.example.backend.analytics;
+
+import com.example.backend.currency.Currency;
+import com.example.backend.currency.HistoricalKline;
+import com.example.backend.exceptions.CurrencyNotFoundException;
+import com.example.backend.exceptions.NotEnoughDataForCalculationException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.springframework.test.util.AssertionErrors.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class CciIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private CciCalculator cciCalculator;
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cciTestCases")
+    void testCciCalculation(String testName,
+                            List<HistoricalKline> klines,
+                            BigDecimal expectedValue,
+                            boolean expectException) {
+        Currency currency = createAndSaveCurrency("ROYAL_COIN", "toMarka");
+
+        for (HistoricalKline kline : klines) {
+            createAndSaveHistoricalKline(
+                    currency,
+                    "1h",
+                    kline.getOpenTime(),
+                    kline.getOpenPrice().doubleValue(),
+                    kline.getHighPrice().doubleValue(),
+                    kline.getLowPrice().doubleValue(),
+                    kline.getClosePrice().doubleValue(),
+                    kline.getCloseTime()
+            );
+        }
+
+        try {
+            BigDecimal result = cciCalculator.calculate(klines);
+
+            if (expectException) {
+                fail("Expected NotEnoughDataForCalculationException but no exception was thrown! Test: " + testName);
+            }
+
+            assertNotNull("CCI result should not be null!", result);
+            assertEquals(
+                    "CCI calculation mismatch for test: " + testName,
+                    0,
+                    expectedValue.compareTo(result)
+            );
+
+        } catch (NotEnoughDataForCalculationException e) {
+            if (!expectException) {
+                fail("NotEnoughDataForCalculationException was not expected for: " + testName);
+            }
+        } catch (CurrencyNotFoundException e) {
+            fail("CurrencyNotFoundException should not happen in this test!");
+        }
+    }
+
+    static Stream<Arguments> cciTestCases() {
+        return Stream.of(
+                Arguments.of(
+                        "Standard calculation (21 klines)",
+                        buildKlines(21),
+                        new BigDecimal("126.7"),
+                        false
+                ),
+                Arguments.of(
+                        "Not enough data => expect exception",
+                        buildKlines(19),
+                        null,
+                        true
+                ),
+                Arguments.of(
+                        "All prices identical so result = 0 (meanDeviation=0)",
+                        buildKlinesSamePrices(),
+                        BigDecimal.ZERO,
+                        false
+                )
+        );
+    }
+
+    private static List<HistoricalKline> buildKlines(int count) {
+        return CciCalculatorTest.createKlines(count, 120, 100, 110);
+    }
+
+    private static List<HistoricalKline> buildKlinesSamePrices() {
+        return CciCalculatorTest.createKlinesWithSamePrices();
+    }
+}


### PR DESCRIPTION
- Implement CciCalculator to calculate Commodity Channel index indicator
- Add rest endpoint to fetch CCI values
- Include unit tests to validate calculation logic
- Add integration tests to verify database and service interaction