### PR TITLE
Implement soft delete for portfolios and enhance portfolio creation

### DIFF
--- a/Trading-Simulator/backend/src/main/java/com/example/backend/admin/AdminPortfolioController.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/admin/AdminPortfolioController.java
@@ -75,7 +75,7 @@ public class AdminPortfolioController {
     })
     public ResponseEntity<String> deletePortfolio(
             @Parameter(description = "ID of the portfolio to delete") @PathVariable Integer portfolioId) {
-        portfolioService.deletePortfolioById(portfolioId);
+        portfolioService.deletePortfolioForAdmin(portfolioId);
         return ResponseEntity.ok("Portfolio has been deleted");
     }
 

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/currency/Currency.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/currency/Currency.java
@@ -10,7 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.util.List;
 
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
@@ -31,7 +32,6 @@ public class Currency {
     private String name;
 
     @OneToMany(mappedBy = "currency", cascade = CascadeType.ALL, orphanRemoval = true)
-    @JsonBackReference
     @JsonIgnore
     @Schema(description = "List of portfolio assets associated with this currency")
     private List<PortfolioAsset> portfolioAssets;

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/Portfolio.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/Portfolio.java
@@ -47,4 +47,7 @@ public class Portfolio {
     @OneToMany(mappedBy = "portfolio", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     @Schema(description = "List of assets contained in the portfolio")
     private List<PortfolioAsset> portfolioAssets = new ArrayList<>();
+
+    @Column(nullable = false)
+    private boolean deleted = false;
 }

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/PortfolioController.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/PortfolioController.java
@@ -2,7 +2,6 @@ package com.example.backend.portfolio;
 
 import com.example.backend.exceptions.ErrorResponse;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,5 +84,18 @@ public class PortfolioController {
             @Parameter(description = "ID of the portfolio to calculate") @PathVariable Integer id) {
         BigDecimal gainOrLoss = portfolioService.calculateTotalPortfolioGainOrLoss(id);
         return ResponseEntity.ok(gainOrLoss);
+    }
+
+    @DeleteMapping("/{id}/delete-portfolio")
+    @Operation(summary = "Delete portfolio with assets",
+    description = "Endpoint that sells all assets in portfolio and then deletes the portfolio")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Portfolio deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Portfolio not found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<String> deletePortfolio(
+            @Parameter(description = "ID of the portfolio to delete") @PathVariable Integer id) {
+        portfolioService.deletePortfolioForUser(id);
+        return ResponseEntity.ok("Portfolio has been deleted");
     }
 }

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/PortfolioRepository.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/portfolio/PortfolioRepository.java
@@ -21,13 +21,30 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Integer> {
 
     Page<Portfolio> findByUser(User user, Pageable pageable);
 
-    void deleteAllByUser(User user);
-
     Optional<Portfolio> findByPortfolioidAndUser(Integer portfolioid, User user);
-
+    List<Portfolio> findByUserAndDeletedFalse(User user);
     Optional<Portfolio> findByUserAndName(User user, String name);
 
+    @Query("""
+    SELECT p
+    FROM Portfolio p
+    WHERE p.user = :user
+      AND p.name = :name
+      AND p.deleted = false
+    """)
+    Optional<Portfolio> findActiveByUserAndName(@Param("user") User user, @Param("name") String name);
+
     @EntityGraph(attributePaths = {"portfolioAssets.currency", "portfolioAssets"})
-    @Query("SELECT p FROM Portfolio p WHERE p.portfolioid = :portfolioid AND p.user = :user")
-    Optional<Portfolio> findWithAssetsByPortfolioidAndUser(@Param("portfolioid") Integer portfolioid, @Param("user") User user);
+    @Query("""
+    SELECT p 
+    FROM Portfolio p 
+    WHERE p.portfolioid = :portfolioid 
+      AND p.user = :user 
+      AND p.deleted = false
+    """)
+    Optional<Portfolio> findWithAssetsByPortfolioidAndUserAndDeletedFalse(
+            @Param("portfolioid") Integer portfolioid,
+            @Param("user") User user
+    );
+
 }

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/user/User.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/user/User.java
@@ -1,10 +1,7 @@
 package com.example.backend.user;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -20,7 +17,8 @@ import java.util.Collection;
 import java.util.List;
 
 @Builder
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity

--- a/Trading-Simulator/backend/src/main/java/com/example/backend/userEvent/UserEvent.java
+++ b/Trading-Simulator/backend/src/main/java/com/example/backend/userEvent/UserEvent.java
@@ -48,6 +48,7 @@ public class UserEvent {
         BUY_CRYPTO,
         SELL_CRYPTO,
         CREATE_PORTFOLIO,
+        DELETE_PORTFOLIO,
         DELETE_NOTIFICATION,
         CHANGE_PASSWORD,
         CHANGE_EMAIL,


### PR DESCRIPTION
- Added `deleted` flag to the Portfolio entity for soft deletion.
- Modified portfolio deletion logic:
  - Assets are sold before marking the portfolio as deleted.
- Updated repository methods to exclude deleted portfolios from queries.
  - created `findActiveByUserAndName` to check for existing active portfolios.
- Adjusted `createPortfolio` to ignore deleted portfolios when validating unique names.
- Enhanced logging for portfolio deletion to capture both invoker and owner details.